### PR TITLE
fix: align implementation with specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration is done via environment variables:
 | `CHECK_INTERVAL` | Interval between health checks | `30s` |
 | `READ_TIMEOUT` | Timeout for canary file reads | `5s` |
 | `DEBOUNCE_THRESHOLD` | Consecutive failures before unhealthy | `3` |
+| `SHUTDOWN_TIMEOUT` | Maximum time for graceful shutdown | `30s` |
 | `HTTP_PORT` | Port for health probe endpoints | `8080` |
 | `LOG_LEVEL` | Log level (debug, info, warn, error) | `info` |
 | `LOG_FORMAT` | Log format (json, text) | `json` |

--- a/specs/001-mount-health-monitor/tasks.md
+++ b/specs/001-mount-health-monitor/tasks.md
@@ -24,12 +24,12 @@
 
 **Purpose**: Project initialization, Go module setup, and CI configuration
 
-- [ ] T001 Create project directory structure per plan.md (cmd/, internal/, .github/)
-- [ ] T002 Initialize Go module with `go mod init` in repository root
-- [ ] T003 [P] Create Dockerfile for multi-stage build in Dockerfile (repository root)
-- [ ] T004 [P] Create debug Dockerfile with Alpine base in Dockerfile.debug (repository root)
-- [ ] T005 [P] Create GitHub Actions CI workflow in .github/workflows/ci.yml (FR-016: build ARM64/AMD64, run tests)
-- [ ] T006 [P] Create .gitignore for Go project in repository root
+- [x] T001 Create project directory structure per plan.md (cmd/, internal/, .github/)
+- [x] T002 Initialize Go module with `go mod init` in repository root
+- [x] T003 [P] Create Dockerfile for multi-stage build in Dockerfile (repository root)
+- [x] T004 [P] Create debug Dockerfile with Alpine base in Dockerfile.debug (repository root)
+- [x] T005 [P] Create GitHub Actions CI workflow in .github/workflows/ci.yml (FR-016: build ARM64/AMD64, run tests)
+- [x] T006 [P] Create .gitignore for Go project in repository root
 
 ---
 
@@ -39,12 +39,12 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T007 Implement Config struct and parsing in internal/config/config.go (FR-011: env vars + flags)
-- [ ] T008 Implement config validation rules in internal/config/config.go
-- [ ] T009 [P] Implement HealthStatus enum in internal/health/state.go
-- [ ] T010 [P] Implement Mount struct in internal/health/state.go
-- [ ] T011 Implement structured logging setup in cmd/mount-monitor/main.go (FR-012, FR-013: stdout/stderr, JSON format)
-- [ ] T012 [P] Write unit tests for config parsing in tests/unit/config_test.go
+- [x] T007 Implement Config struct and parsing in internal/config/config.go (FR-011: env vars + flags)
+- [x] T008 Implement config validation rules in internal/config/config.go
+- [x] T009 [P] Implement HealthStatus enum in internal/health/state.go
+- [x] T010 [P] Implement Mount struct in internal/health/state.go
+- [x] T011 Implement structured logging setup in cmd/mount-monitor/main.go (FR-012, FR-013: stdout/stderr, JSON format)
+- [x] T012 [P] Write unit tests for config parsing in tests/unit/config_test.go
 
 **Checkpoint**: Foundation ready - user story implementation can now begin
 
@@ -58,18 +58,18 @@
 
 ### Tests for User Story 1
 
-- [ ] T013 [P] [US1] Write unit tests for health checker in tests/unit/checker_test.go
-- [ ] T014 [P] [US1] Write unit tests for state management in tests/unit/state_test.go
+- [x] T013 [P] [US1] Write unit tests for health checker in tests/unit/checker_test.go
+- [x] T014 [P] [US1] Write unit tests for state management in tests/unit/state_test.go
 
 ### Implementation for User Story 1
 
-- [ ] T015 [US1] Implement CheckResult struct in internal/health/state.go
-- [ ] T016 [US1] Implement StateTransition struct in internal/health/state.go
-- [ ] T017 [US1] Implement canary file health check with timeout in internal/health/checker.go (FR-002: read canary file, 5s default timeout)
-- [ ] T018 [US1] Implement debounce/threshold logic in internal/health/state.go (FR-004: 3 consecutive failures)
-- [ ] T019 [US1] Implement state transition detection and logging in internal/health/state.go (FR-007: log transitions)
-- [ ] T020 [US1] Implement Monitor struct and health check loop in internal/monitor/monitor.go (FR-001, FR-003: multiple mounts, 30s interval)
-- [ ] T021 [US1] Wire up monitor in main.go entry point in cmd/mount-monitor/main.go
+- [x] T015 [US1] Implement CheckResult struct in internal/health/state.go
+- [x] T016 [US1] Implement StateTransition struct in internal/health/state.go
+- [x] T017 [US1] Implement canary file health check with timeout in internal/health/checker.go (FR-002: read canary file, 5s default timeout)
+- [x] T018 [US1] Implement debounce/threshold logic in internal/health/state.go (FR-004: 3 consecutive failures)
+- [x] T019 [US1] Implement state transition detection and logging in internal/health/state.go (FR-007: log transitions)
+- [x] T020 [US1] Implement Monitor struct and health check loop in internal/monitor/monitor.go (FR-001, FR-003: multiple mounts, 30s interval)
+- [x] T021 [US1] Wire up monitor in main.go entry point in cmd/mount-monitor/main.go
 
 **Checkpoint**: User Story 1 complete - monitor detects and logs mount health changes
 
@@ -85,15 +85,15 @@
 
 ### Tests for User Story 2
 
-- [ ] T022 [P] [US2] Write unit tests for liveness endpoint in tests/unit/server_test.go
+- [x] T022 [P] [US2] Write unit tests for liveness endpoint in tests/unit/server_test.go
 
 ### Implementation for User Story 2
 
-- [ ] T023 [US2] Implement ProbeResponse and MountStatus structs in internal/server/server.go
-- [ ] T024 [US2] Implement HTTP server with /healthz/live endpoint in internal/server/server.go (FR-005, FR-015: HTTP 200/503)
-- [ ] T025 [US2] Implement liveness probe logic (HEALTHY/DEGRADED=200, UNHEALTHY=503) in internal/server/server.go
-- [ ] T026 [US2] Add probe response logging in internal/server/server.go (FR-008: log probe queries)
-- [ ] T027 [US2] Wire up HTTP server in main.go in cmd/mount-monitor/main.go
+- [x] T023 [US2] Implement ProbeResponse and MountStatus structs in internal/server/server.go
+- [x] T024 [US2] Implement HTTP server with /healthz/live endpoint in internal/server/server.go (FR-005, FR-015: HTTP 200/503)
+- [x] T025 [US2] Implement liveness probe logic (HEALTHY/DEGRADED=200, UNHEALTHY=503) in internal/server/server.go
+- [x] T026 [US2] Add probe response logging in internal/server/server.go (FR-008: log probe queries)
+- [x] T027 [US2] Wire up HTTP server in main.go in cmd/mount-monitor/main.go
 
 **Checkpoint**: User Story 2 complete - liveness probe triggers pod restart on confirmed unhealthy state
 
@@ -109,12 +109,12 @@
 
 ### Tests for User Story 3
 
-- [ ] T028 [P] [US3] Write unit tests for readiness endpoint in tests/unit/server_test.go (extend existing)
+- [x] T028 [P] [US3] Write unit tests for readiness endpoint in tests/unit/server_test.go (extend existing)
 
 ### Implementation for User Story 3
 
-- [ ] T029 [US3] Implement /healthz/ready endpoint in internal/server/server.go (FR-006, FR-015: HTTP 200/503)
-- [ ] T030 [US3] Implement readiness probe logic (only HEALTHY=200, any other state=503) in internal/server/server.go
+- [x] T029 [US3] Implement /healthz/ready endpoint in internal/server/server.go (FR-006, FR-015: HTTP 200/503)
+- [x] T030 [US3] Implement readiness probe logic (only HEALTHY=200, any other state=503) in internal/server/server.go
 
 **Checkpoint**: User Story 3 complete - readiness probe gates service startup until all mounts healthy
 
@@ -134,11 +134,11 @@
 
 ### Implementation for User Story 4
 
-- [ ] T032 [US4] Implement signal handler for SIGTERM/SIGINT in cmd/mount-monitor/main.go (FR-009)
-- [ ] T033 [US4] Implement graceful HTTP server shutdown in internal/server/server.go
-- [ ] T034 [US4] Implement graceful monitor loop shutdown in internal/monitor/monitor.go
-- [ ] T035 [US4] Implement shutdown timeout (30s) and exit code handling in cmd/mount-monitor/main.go (FR-010, FR-014)
-- [ ] T036 [US4] Add shutdown logging in cmd/mount-monitor/main.go
+- [x] T032 [US4] Implement signal handler for SIGTERM/SIGINT in cmd/mount-monitor/main.go (FR-009)
+- [x] T033 [US4] Implement graceful HTTP server shutdown in internal/server/server.go
+- [x] T034 [US4] Implement graceful monitor loop shutdown in internal/monitor/monitor.go
+- [x] T035 [US4] Implement shutdown timeout (30s) and exit code handling in cmd/mount-monitor/main.go (FR-010, FR-014)
+- [x] T036 [US4] Add shutdown logging in cmd/mount-monitor/main.go
 
 **Checkpoint**: User Story 4 complete - service shuts down gracefully on termination signals
 
@@ -150,8 +150,8 @@
 
 - [x] T037 [P] Write end-to-end integration test in tests/unit/monitor_test.go
 - [ ] T038 Validate quickstart.md scenarios work correctly
-- [ ] T039 [P] Update README.md with build and usage instructions
-- [ ] T040 Run full test suite and verify CI passes
+- [x] T039 [P] Update README.md with build and usage instructions
+- [x] T040 Run full test suite and verify CI passes
 - [ ] T041 Build and verify container image size (<20MB target)
 
 ---

--- a/tests/unit/server_test.go
+++ b/tests/unit/server_test.go
@@ -2,17 +2,36 @@ package unit
 
 import (
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/chris/debrid-mount-monitor/internal/health"
+	"github.com/chris/debrid-mount-monitor/internal/server"
 )
 
-func TestLivenessEndpoint_AlwaysReturns200(t *testing.T) {
+// testLogger returns a silent logger for testing.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestLivenessEndpoint_HealthyMount tests liveness returns 200 for healthy mounts.
+func TestLivenessEndpoint_HealthyMount(t *testing.T) {
 	mount := health.NewMount("/mnt/test", ".health-check")
-	handler := createTestHandler([]*health.Mount{mount})
+	// Make mount healthy
+	result := &health.CheckResult{
+		Mount:     mount,
+		Timestamp: time.Now(),
+		Success:   true,
+		Duration:  100 * time.Millisecond,
+	}
+	mount.UpdateState(result, 3)
+
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz/live", nil)
 	rec := httptest.NewRecorder()
@@ -23,85 +42,27 @@ func TestLivenessEndpoint_AlwaysReturns200(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	var response map[string]string
+	var response map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
 
-	if response["status"] != "alive" {
-		t.Errorf("expected status 'alive', got %q", response["status"])
+	if response["status"] != "healthy" {
+		t.Errorf("expected status 'healthy', got %q", response["status"])
+	}
+
+	// Verify OpenAPI-compliant response has timestamp and mounts
+	if _, ok := response["timestamp"]; !ok {
+		t.Error("response missing 'timestamp' field")
+	}
+	if _, ok := response["mounts"]; !ok {
+		t.Error("response missing 'mounts' field")
 	}
 }
 
-func TestReadinessEndpoint_AllHealthy(t *testing.T) {
-	mount := health.NewMount("/mnt/test", ".health-check")
-	// Simulate healthy state
-	result := &health.CheckResult{
-		Mount:     mount,
-		Timestamp: time.Now(),
-		Success:   true,
-		Duration:  100 * time.Millisecond,
-	}
-	mount.UpdateState(result, 3)
-
-	handler := createTestHandler([]*health.Mount{mount})
-
-	req := httptest.NewRequest(http.MethodGet, "/healthz/ready", nil)
-	rec := httptest.NewRecorder()
-
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected status 200, got %d", rec.Code)
-	}
-
-	var response map[string]string
-	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
-
-	if response["status"] != "ready" {
-		t.Errorf("expected status 'ready', got %q", response["status"])
-	}
-}
-
-func TestReadinessEndpoint_UnhealthyMount(t *testing.T) {
-	mount := health.NewMount("/mnt/test", ".health-check")
-	debounceThreshold := 3
-
-	// Simulate unhealthy state (3 failures)
-	for i := 0; i < debounceThreshold; i++ {
-		result := &health.CheckResult{
-			Mount:     mount,
-			Timestamp: time.Now(),
-			Success:   false,
-			Duration:  100 * time.Millisecond,
-		}
-		mount.UpdateState(result, debounceThreshold)
-	}
-
-	handler := createTestHandler([]*health.Mount{mount})
-
-	req := httptest.NewRequest(http.MethodGet, "/healthz/ready", nil)
-	rec := httptest.NewRecorder()
-
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Errorf("expected status 503, got %d", rec.Code)
-	}
-
-	var response map[string]string
-	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
-
-	if response["status"] != "not_ready" {
-		t.Errorf("expected status 'not_ready', got %q", response["status"])
-	}
-}
-
-func TestReadinessEndpoint_DegradedMount_StillReady(t *testing.T) {
+// TestLivenessEndpoint_DegradedMount tests liveness returns 200 for degraded mounts.
+// Per spec: degraded (within debounce) should NOT trigger liveness failure.
+func TestLivenessEndpoint_DegradedMount(t *testing.T) {
 	mount := health.NewMount("/mnt/test", ".health-check")
 	debounceThreshold := 3
 
@@ -118,19 +79,218 @@ func TestReadinessEndpoint_DegradedMount_StillReady(t *testing.T) {
 		t.Fatalf("expected mount to be degraded, got %v", mount.GetStatus())
 	}
 
-	handler := createTestHandler([]*health.Mount{mount})
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/live", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Degraded mounts should return 200 (only UNHEALTHY triggers 503)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200 for degraded mount, got %d", rec.Code)
+	}
+}
+
+// TestLivenessEndpoint_UnhealthyMount tests liveness returns 503 for unhealthy mounts.
+// Per spec: liveness returns 503 when mount is UNHEALTHY (past debounce threshold).
+func TestLivenessEndpoint_UnhealthyMount(t *testing.T) {
+	mount := health.NewMount("/mnt/test", ".health-check")
+	debounceThreshold := 3
+
+	// Simulate unhealthy state (3 failures)
+	for i := 0; i < debounceThreshold; i++ {
+		result := &health.CheckResult{
+			Mount:     mount,
+			Timestamp: time.Now(),
+			Success:   false,
+			Duration:  100 * time.Millisecond,
+		}
+		mount.UpdateState(result, debounceThreshold)
+	}
+
+	if mount.GetStatus() != health.StatusUnhealthy {
+		t.Fatalf("expected mount to be unhealthy, got %v", mount.GetStatus())
+	}
+
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/live", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Unhealthy mounts should trigger 503
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 for unhealthy mount, got %d", rec.Code)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["status"] != "unhealthy" {
+		t.Errorf("expected status 'unhealthy', got %q", response["status"])
+	}
+}
+
+// TestLivenessEndpoint_UnknownMount tests liveness returns 200 for unknown mounts.
+// Per spec: unknown (no check yet) should NOT trigger liveness failure.
+func TestLivenessEndpoint_UnknownMount(t *testing.T) {
+	mount := health.NewMount("/mnt/test", ".health-check")
+	// Mount starts in UNKNOWN state (no checks performed)
+
+	if mount.GetStatus() != health.StatusUnknown {
+		t.Fatalf("expected mount to be unknown, got %v", mount.GetStatus())
+	}
+
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/live", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Unknown mounts should return 200 (grace period)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200 for unknown mount, got %d", rec.Code)
+	}
+}
+
+// TestReadinessEndpoint_AllHealthy tests readiness returns 200 when all mounts are healthy.
+func TestReadinessEndpoint_AllHealthy(t *testing.T) {
+	mount := health.NewMount("/mnt/test", ".health-check")
+	// Simulate healthy state
+	result := &health.CheckResult{
+		Mount:     mount,
+		Timestamp: time.Now(),
+		Success:   true,
+		Duration:  100 * time.Millisecond,
+	}
+	mount.UpdateState(result, 3)
+
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz/ready", nil)
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
 
-	// Degraded mounts should still return 200 (only unhealthy triggers 503)
 	if rec.Code != http.StatusOK {
-		t.Errorf("expected status 200 for degraded mount, got %d", rec.Code)
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["status"] != "healthy" {
+		t.Errorf("expected status 'healthy', got %q", response["status"])
 	}
 }
 
+// TestReadinessEndpoint_UnhealthyMount tests readiness returns 503 when any mount is unhealthy.
+func TestReadinessEndpoint_UnhealthyMount(t *testing.T) {
+	mount := health.NewMount("/mnt/test", ".health-check")
+	debounceThreshold := 3
+
+	// Simulate unhealthy state (3 failures)
+	for i := 0; i < debounceThreshold; i++ {
+		result := &health.CheckResult{
+			Mount:     mount,
+			Timestamp: time.Now(),
+			Success:   false,
+			Duration:  100 * time.Millisecond,
+		}
+		mount.UpdateState(result, debounceThreshold)
+	}
+
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/ready", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", rec.Code)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["status"] != "unhealthy" {
+		t.Errorf("expected status 'unhealthy', got %q", response["status"])
+	}
+}
+
+// TestReadinessEndpoint_DegradedMount tests readiness returns 503 for degraded mounts.
+// Per spec: readiness requires HEALTHY state - degraded triggers 503.
+func TestReadinessEndpoint_DegradedMount(t *testing.T) {
+	mount := health.NewMount("/mnt/test", ".health-check")
+	debounceThreshold := 3
+
+	// Simulate degraded state (1 failure, below threshold)
+	result := &health.CheckResult{
+		Mount:     mount,
+		Timestamp: time.Now(),
+		Success:   false,
+		Duration:  100 * time.Millisecond,
+	}
+	mount.UpdateState(result, debounceThreshold)
+
+	if mount.GetStatus() != health.StatusDegraded {
+		t.Fatalf("expected mount to be degraded, got %v", mount.GetStatus())
+	}
+
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/ready", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Per spec: DEGRADED should return 503 for readiness
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 for degraded mount, got %d", rec.Code)
+	}
+}
+
+// TestReadinessEndpoint_UnknownMount tests readiness returns 503 for unknown mounts.
+// Per spec: readiness requires HEALTHY - unknown (no check yet) triggers 503.
+func TestReadinessEndpoint_UnknownMount(t *testing.T) {
+	mount := health.NewMount("/mnt/test", ".health-check")
+	// Mount starts in UNKNOWN state (no checks performed)
+
+	if mount.GetStatus() != health.StatusUnknown {
+		t.Fatalf("expected mount to be unknown, got %v", mount.GetStatus())
+	}
+
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/ready", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Per spec: UNKNOWN should return 503 for readiness
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 for unknown mount, got %d", rec.Code)
+	}
+}
+
+// TestStatusEndpoint_DetailedInfo tests the status endpoint returns detailed mount info.
 func TestStatusEndpoint_DetailedInfo(t *testing.T) {
 	mount1 := health.NewMount("/mnt/test1", ".health-check")
 	mount2 := health.NewMount("/mnt/test2", ".health-check")
@@ -144,16 +304,17 @@ func TestStatusEndpoint_DetailedInfo(t *testing.T) {
 	}
 	mount1.UpdateState(result1, 3)
 
-	// Mount2: degraded (1 failure)
+	// Mount2: also healthy
 	result2 := &health.CheckResult{
 		Mount:     mount2,
 		Timestamp: time.Now(),
-		Success:   false,
+		Success:   true,
 		Duration:  100 * time.Millisecond,
 	}
 	mount2.UpdateState(result2, 3)
 
-	handler := createTestHandler([]*health.Mount{mount1, mount2})
+	srv := server.New([]*health.Mount{mount1, mount2}, 0, testLogger())
+	handler := createServerHandler(srv)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz/status", nil)
 	rec := httptest.NewRecorder()
@@ -165,8 +326,9 @@ func TestStatusEndpoint_DetailedInfo(t *testing.T) {
 	}
 
 	var response struct {
-		Status string `json:"status"`
-		Mounts []struct {
+		Status    string `json:"status"`
+		Timestamp string `json:"timestamp"`
+		Mounts    []struct {
 			Path         string `json:"path"`
 			Status       string `json:"status"`
 			FailureCount int    `json:"failure_count"`
@@ -180,6 +342,10 @@ func TestStatusEndpoint_DetailedInfo(t *testing.T) {
 		t.Errorf("expected overall status 'healthy', got %q", response.Status)
 	}
 
+	if response.Timestamp == "" {
+		t.Error("response missing timestamp")
+	}
+
 	if len(response.Mounts) != 2 {
 		t.Fatalf("expected 2 mounts, got %d", len(response.Mounts))
 	}
@@ -187,14 +353,44 @@ func TestStatusEndpoint_DetailedInfo(t *testing.T) {
 	if response.Mounts[0].Status != "healthy" {
 		t.Errorf("expected mount1 status 'healthy', got %q", response.Mounts[0].Status)
 	}
-	if response.Mounts[1].Status != "degraded" {
-		t.Errorf("expected mount2 status 'degraded', got %q", response.Mounts[1].Status)
+	if response.Mounts[1].Status != "healthy" {
+		t.Errorf("expected mount2 status 'healthy', got %q", response.Mounts[1].Status)
 	}
 }
 
+// TestStatusEndpoint_DegradedMount tests status returns 503 when any mount is degraded.
+// Per spec: status endpoint uses same logic as readiness.
+func TestStatusEndpoint_DegradedMount(t *testing.T) {
+	mount := health.NewMount("/mnt/test", ".health-check")
+
+	// Simulate degraded state (1 failure)
+	result := &health.CheckResult{
+		Mount:     mount,
+		Timestamp: time.Now(),
+		Success:   false,
+		Duration:  100 * time.Millisecond,
+	}
+	mount.UpdateState(result, 3)
+
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/status", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Per spec: degraded should return 503
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 for degraded mount, got %d", rec.Code)
+	}
+}
+
+// TestEndpoints_MethodNotAllowed tests that non-GET methods return 405.
 func TestEndpoints_MethodNotAllowed(t *testing.T) {
 	mount := health.NewMount("/mnt/test", ".health-check")
-	handler := createTestHandler([]*health.Mount{mount})
+	srv := server.New([]*health.Mount{mount}, 0, testLogger())
+	handler := createServerHandler(srv)
 
 	endpoints := []string{"/healthz/live", "/healthz/ready", "/healthz/status"}
 	methods := []string{http.MethodPost, http.MethodPut, http.MethodDelete}
@@ -215,85 +411,8 @@ func TestEndpoints_MethodNotAllowed(t *testing.T) {
 	}
 }
 
-// createTestHandler creates an HTTP handler for testing without starting a server.
-func createTestHandler(mounts []*health.Mount) http.Handler {
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/healthz/live", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"status": "alive"})
-	})
-
-	mux.HandleFunc("/healthz/ready", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		allHealthy := true
-		for _, mount := range mounts {
-			if mount.GetStatus() == health.StatusUnhealthy {
-				allHealthy = false
-				break
-			}
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if allHealthy {
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			json.NewEncoder(w).Encode(map[string]string{"status": "not_ready"})
-		}
-	})
-
-	mux.HandleFunc("/healthz/status", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		overallHealthy := true
-		mountStatuses := make([]map[string]any, len(mounts))
-
-		for i, mount := range mounts {
-			snapshot := mount.Snapshot()
-			if snapshot.Status == health.StatusUnhealthy {
-				overallHealthy = false
-			}
-
-			mountStatuses[i] = map[string]any{
-				"path":          snapshot.Path,
-				"status":        snapshot.Status.String(),
-				"failure_count": snapshot.FailureCount,
-			}
-			if snapshot.LastError != "" {
-				mountStatuses[i]["last_error"] = snapshot.LastError
-			}
-		}
-
-		status := "healthy"
-		if !overallHealthy {
-			status = "unhealthy"
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if overallHealthy {
-			w.WriteHeader(http.StatusOK)
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-		}
-		json.NewEncoder(w).Encode(map[string]any{
-			"status": status,
-			"mounts": mountStatuses,
-		})
-	})
-
-	return mux
+// createServerHandler creates an HTTP handler from the real server for testing.
+// Uses the server's Handler() method to get the internal mux for direct testing.
+func createServerHandler(srv *server.Server) http.Handler {
+	return srv.Handler()
 }


### PR DESCRIPTION
## Summary

This PR fixes 6 inconsistencies identified during a deep spec compliance review comparing the implementation against `specs/001-mount-health-monitor/spec.md` and `contracts/openapi.yaml`.

### Significant Fixes

- **Readiness probe** now returns 503 for ANY non-HEALTHY state (DEGRADED, UNKNOWN, UNHEALTHY) per FR-006
- **Liveness probe** now returns 503 when mounts are UNHEALTHY (past debounce) per FR-005  
- **Logging streams** now route by level: debug/info → stdout, warn/error → stderr per FR-012

### Minor Fixes

- API responses now match OpenAPI `ProbeResponse` schema (status, timestamp, mounts)
- Added missing `SHUTDOWN_TIMEOUT` to README configuration table
- Updated `tasks.md` to mark all 39 implemented tasks as complete

## Files Changed

| File | Changes |
|------|---------|
| `internal/server/server.go` | Probe logic fixes, `buildProbeResponse()` helper |
| `cmd/mount-monitor/main.go` | `multiStreamHandler` for log routing |
| `tests/unit/server_test.go` | Updated tests for spec-compliant behavior |
| `README.md` | Added SHUTDOWN_TIMEOUT |
| `specs/001-mount-health-monitor/tasks.md` | Marked tasks complete |

## Test plan

- [x] All unit tests pass with race detection (`go test -race ./...`)
- [x] New tests cover liveness/readiness for all 4 states (UNKNOWN, HEALTHY, DEGRADED, UNHEALTHY)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual verification of logging streams (run with `LOG_LEVEL=debug` and check stdout/stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)