### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
 
   lint:
     name: Lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/cscheib/debrid-mount-monitor/security/code-scanning/4](https://github.com/cscheib/debrid-mount-monitor/security/code-scanning/4)

To fix the issue, add a `permissions` block to the `lint` job (line 82) specifying only the minimal required access. According to CodeQL's hint, the least privilege required in this case is `contents: read` since the job only needs to checkout code and run Go-related tools, but does not need to push changes or interact with GitHub PR/issues. No other authentication scopes are involved.

- Edit the `.github/workflows/ci.yml` file.
- Indent the `permissions` block to match the other job keys.
- Add directly under `name: Lint` (after line 82):

```yaml
    permissions:
      contents: read
```

No other modifications, new imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
