### PR TITLE
Add directory mount checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Create a `config.json` file in your working directory or specify a path with `--
     {
       "name": "tv",
       "path": "/mnt/tv",
+      "checkType": "directory",
       "failureThreshold": 5
     },
     {
@@ -63,6 +64,7 @@ Create a `config.json` file in your working directory or specify a path with `--
 Each mount can override global settings:
 - `name`: Human-readable identifier (shown in logs and status)
 - `path`: Filesystem path to mount point (required) - can be absolute or relative
+- `checkType`: Health check type: `canary` (default) reads a canary file; `directory` checks that `path` exists and is a directory
 - `canaryFile`: Override global canary file for this mount (always relative to mount path)
 - `failureThreshold`: Override global failure threshold for this mount
 
@@ -75,6 +77,8 @@ Each mount can override global settings:
 Relative paths are resolved from the working directory where the monitor runs.
 
 **Canary Files:** Canary file paths are always relative to their respective mount path. For example, with a mount at `/mnt/movies` and canary file `.health-check`, the full canary path is `/mnt/movies/.health-check`.
+
+**Directory Checks:** Set `checkType` to `directory` when the mounted source does not expose a stable canary file. Directory checks verify that the configured `path` exists and is a directory. This is useful for virtual mounts such as Decypharr WebDAV/rclone paths, but it is a weaker signal than reading a file because it does not prove file reads from the mount are healthy.
 
 ### CLI Flags
 

--- a/cmd/mount-monitor/main.go
+++ b/cmd/mount-monitor/main.go
@@ -64,13 +64,17 @@ func main() {
 	// Create mounts from configuration
 	mounts := make([]*health.Mount, len(cfg.Mounts))
 	for i, mc := range cfg.Mounts {
-		mounts[i] = health.NewMount(mc.Name, mc.Path, mc.CanaryFile, mc.FailureThreshold)
-		logger.Info("mount registered",
+		mounts[i] = health.NewMountWithCheckType(mc.Name, mc.Path, mc.CanaryFile, mc.CheckType, mc.FailureThreshold)
+		attrs := []any{
 			"name", mc.Name,
 			"path", mc.Path,
-			"canary", mounts[i].CanaryPath,
+			"check_type", mounts[i].CheckType,
 			"failureThreshold", mc.FailureThreshold,
-		)
+		}
+		if mounts[i].CheckType == health.CheckTypeCanary {
+			attrs = append(attrs, "canary", mounts[i].CanaryPath)
+		}
+		logger.Info("mount registered", attrs...)
 	}
 
 	// Create health checker
@@ -245,7 +249,7 @@ func runInitMode(cfg *config.Config, logger *slog.Logger) int {
 	// Create mounts from configuration
 	mounts := make([]*health.Mount, len(cfg.Mounts))
 	for i, mc := range cfg.Mounts {
-		mounts[i] = health.NewMount(mc.Name, mc.Path, mc.CanaryFile, mc.FailureThreshold)
+		mounts[i] = health.NewMountWithCheckType(mc.Name, mc.Path, mc.CanaryFile, mc.CheckType, mc.FailureThreshold)
 	}
 
 	// Create health checker

--- a/config.example.json
+++ b/config.example.json
@@ -17,6 +17,7 @@
     {
       "name": "tv",
       "path": "/mnt/tv",
+      "checkType": "directory",
       "failureThreshold": 5
     }
   ]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type MountConfig struct {
 	Name             string // Human-readable identifier (optional)
 	Path             string // Filesystem path to mount point (required) - can be absolute or relative
 	CanaryFile       string // Relative path to canary file within mount (optional, inherits global)
+	CheckType        string // Health check type: "canary" or "directory" (optional, defaults to canary)
 	FailureThreshold int    // Consecutive failures before unhealthy (0 = use global failureThreshold)
 }
 
@@ -145,6 +146,13 @@ func (c *Config) Validate() error {
 				result = multierror.Append(result, fmt.Errorf("mount[%d] %q: failureThreshold must be >= 0", i, m.Name))
 			} else {
 				result = multierror.Append(result, fmt.Errorf("mount[%d]: failureThreshold must be >= 0", i))
+			}
+		}
+		if m.CheckType != "" && m.CheckType != "canary" && m.CheckType != "directory" {
+			if m.Name != "" {
+				result = multierror.Append(result, fmt.Errorf("mount[%d] %q: checkType must be one of: canary, directory (got %q)", i, m.Name, m.CheckType))
+			} else {
+				result = multierror.Append(result, fmt.Errorf("mount[%d]: checkType must be one of: canary, directory (got %q)", i, m.CheckType))
 			}
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -263,6 +263,35 @@ func TestConfigValidation_MountZeroThreshold(t *testing.T) {
 	is.NoErr(err) // threshold=0 should be valid (sentinel for "use global default")
 }
 
+func TestConfigValidation_MountCheckType(t *testing.T) {
+	tests := []struct {
+		name      string
+		checkType string
+		wantErr   bool
+	}{
+		{"default", "", false},
+		{"canary", "canary", false},
+		{"directory", "directory", false},
+		{"invalid", "http", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
+
+			cfg := config.DefaultConfig()
+			cfg.Mounts = []config.MountConfig{{Path: "/mnt/test", CheckType: tt.checkType}}
+
+			err := cfg.Validate()
+			if tt.wantErr {
+				is.True(err != nil) // invalid checkType should error
+			} else {
+				is.NoErr(err) // valid checkType should pass
+			}
+		})
+	}
+}
+
 // T004: Test that InitContainerMode field exists and defaults to false
 func TestDefaultConfig_InitContainerMode(t *testing.T) {
 	is := is.New(t)

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -65,6 +65,7 @@ type FileMountConfig struct {
 	Name             string `json:"name,omitempty"`
 	Path             string `json:"path"`
 	CanaryFile       string `json:"canaryFile,omitempty"`
+	CheckType        string `json:"checkType,omitempty"`
 	FailureThreshold int    `json:"failureThreshold,omitempty"` // 0 = use global default, >= 1 = explicit value
 }
 
@@ -160,6 +161,12 @@ func validateFileConfig(fc *FileConfig) error {
 			}
 			return fmt.Errorf("mount[%d]: failureThreshold must be >= 0, got %d", i, m.FailureThreshold)
 		}
+		if m.CheckType != "" && m.CheckType != "canary" && m.CheckType != "directory" {
+			if m.Name != "" {
+				return fmt.Errorf("mount[%d] %q: checkType must be one of: canary, directory, got %q", i, m.Name, m.CheckType)
+			}
+			return fmt.Errorf("mount[%d]: checkType must be one of: canary, directory, got %q", i, m.CheckType)
+		}
 	}
 
 	return nil
@@ -201,8 +208,12 @@ func applyFileConfig(c *Config, fc *FileConfig) {
 		for i, fm := range fc.Mounts {
 			// Apply per-mount config with inheritance from globals
 			mc := MountConfig{
-				Name: fm.Name,
-				Path: fm.Path,
+				Name:      fm.Name,
+				Path:      fm.Path,
+				CheckType: fm.CheckType,
+			}
+			if mc.CheckType == "" {
+				mc.CheckType = "canary"
 			}
 
 			// Inherit canary file from global if not specified

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -35,11 +35,12 @@ func TestConfigFile_ValidJSON(t *testing.T) {
 				"canaryFile": ".health-check",
 				"failureThreshold": 3
 			},
-			{
-				"name": "tv",
-				"path": "/mnt/tv",
-				"failureThreshold": 5
-			}
+				{
+					"name": "tv",
+					"path": "/mnt/tv",
+					"checkType": "directory",
+					"failureThreshold": 5
+				}
 		]
 	}`
 
@@ -71,6 +72,7 @@ func TestConfigFile_ValidJSON(t *testing.T) {
 	is.Equal(cfg.Mounts[0].FailureThreshold, 3)         // mount[0].failureThreshold
 	is.Equal(cfg.Mounts[1].Name, "tv")                  // mount[1].name
 	is.Equal(cfg.Mounts[1].Path, "/mnt/tv")             // mount[1].path
+	is.Equal(cfg.Mounts[1].CheckType, "directory")      // mount[1].checkType
 
 	// Verify ConfigFile is set
 	is.Equal(cfg.ConfigFile, configPath) // ConfigFile
@@ -229,6 +231,52 @@ func TestConfigFile_PerMountCanaryOverride(t *testing.T) {
 
 	// Mount without override should inherit global canary file
 	is.Equal(cfg.Mounts[1].CanaryFile, ".global-health") // mount[1] inherited canary
+}
+
+func TestConfigFile_DefaultCheckType(t *testing.T) {
+	is := is.New(t)
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	configJSON := `{
+		"mounts": [
+			{"path": "/mnt/test"}
+		]
+	}`
+
+	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	if err := cfg.LoadFromFileForTesting(configPath); err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	is.Equal(cfg.Mounts[0].CheckType, "canary") // default checkType
+}
+
+func TestConfigFile_InvalidCheckType(t *testing.T) {
+	is := is.New(t)
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	configJSON := `{
+		"mounts": [
+			{"path": "/mnt/test", "checkType": "http"}
+		]
+	}`
+
+	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	err := cfg.LoadFromFileForTesting(configPath)
+
+	is.True(err != nil) // invalid checkType should error
 }
 
 // T021: Test per-mount failureThreshold override

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 )
@@ -44,8 +45,7 @@ func (c *Checker) Check(ctx context.Context, mount *Mount) *CheckResult {
 	// 3. Alternative approaches (goroutine pools) add complexity without solving the root cause
 	done := make(chan error, 1)
 	go func() {
-		_, err := os.ReadFile(mount.CanaryPath)
-		done <- err
+		done <- checkMount(mount)
 	}()
 
 	// Wait for either completion or context cancellation
@@ -65,4 +65,23 @@ func (c *Checker) Check(ctx context.Context, mount *Mount) *CheckResult {
 	}
 
 	return result
+}
+
+func checkMount(mount *Mount) error {
+	switch mount.CheckType {
+	case "", CheckTypeCanary:
+		_, err := os.ReadFile(mount.CanaryPath)
+		return err
+	case CheckTypeDirectory:
+		info, err := os.Stat(mount.Path)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("path is not a directory: %s", mount.Path)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported check type %q", mount.CheckType)
+	}
 }

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -123,3 +123,46 @@ func TestChecker_EmptyCanaryFile(t *testing.T) {
 
 	is.True(result.Success) // empty canary file should be healthy
 }
+
+func TestChecker_DirectoryCheck_ExistingDirectory(t *testing.T) {
+	is := is.New(t)
+
+	tmpDir := t.TempDir()
+	mount := health.NewMountWithCheckType("", tmpDir, "", health.CheckTypeDirectory, 3)
+	checker := health.NewChecker(5 * time.Second)
+
+	result := checker.Check(context.Background(), mount)
+
+	is.True(result.Success) // existing directory should be healthy
+	is.NoErr(result.Error)  // no error expected
+}
+
+func TestChecker_DirectoryCheck_MissingDirectory(t *testing.T) {
+	is := is.New(t)
+
+	mount := health.NewMountWithCheckType("", "/nonexistent/path/that/does/not/exist", "", health.CheckTypeDirectory, 3)
+	checker := health.NewChecker(5 * time.Second)
+
+	result := checker.Check(context.Background(), mount)
+
+	is.True(!result.Success)     // missing directory should fail
+	is.True(result.Error != nil) // error expected
+}
+
+func TestChecker_DirectoryCheck_FilePath(t *testing.T) {
+	is := is.New(t)
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "not-a-directory")
+	if err := os.WriteFile(filePath, []byte("ok"), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	mount := health.NewMountWithCheckType("", filePath, "", health.CheckTypeDirectory, 3)
+	checker := health.NewChecker(5 * time.Second)
+
+	result := checker.Check(context.Background(), mount)
+
+	is.True(!result.Success)     // file path should fail directory check
+	is.True(result.Error != nil) // error expected
+}

--- a/internal/health/state.go
+++ b/internal/health/state.go
@@ -21,6 +21,11 @@ const (
 	StatusUnhealthy
 )
 
+const (
+	CheckTypeCanary    = "canary"
+	CheckTypeDirectory = "directory"
+)
+
 // String returns the string representation of the health status.
 func (s HealthStatus) String() string {
 	switch s {
@@ -42,6 +47,7 @@ type Mount struct {
 	Name             string       // Human-readable identifier (optional)
 	Path             string       // Absolute path to mount point
 	CanaryPath       string       // Full path to canary file
+	CheckType        string       // Type of health check to perform
 	FailureThreshold int          // Consecutive failures before unhealthy (per-mount)
 	Status           HealthStatus // Current health status
 	LastCheck        time.Time    // Timestamp of last health check
@@ -57,14 +63,27 @@ type Mount struct {
 //   - canaryFile: Relative path to canary file within mount
 //   - failureThreshold: Consecutive failures before marking unhealthy
 func NewMount(name, path, canaryFile string, failureThreshold int) *Mount {
-	canaryPath := path
-	if canaryFile != "" {
-		canaryPath = filepath.Join(path, canaryFile)
+	return NewMountWithCheckType(name, path, canaryFile, CheckTypeCanary, failureThreshold)
+}
+
+// NewMountWithCheckType creates a new Mount instance with an explicit check type.
+func NewMountWithCheckType(name, path, canaryFile, checkType string, failureThreshold int) *Mount {
+	if checkType == "" {
+		checkType = CheckTypeCanary
+	}
+
+	canaryPath := ""
+	if checkType == CheckTypeCanary {
+		canaryPath = path
+		if canaryFile != "" {
+			canaryPath = filepath.Join(path, canaryFile)
+		}
 	}
 	return &Mount{
 		Name:             name,
 		Path:             path,
 		CanaryPath:       canaryPath,
+		CheckType:        checkType,
 		FailureThreshold: failureThreshold,
 		Status:           StatusUnknown,
 	}

--- a/internal/health/state_test.go
+++ b/internal/health/state_test.go
@@ -18,9 +18,22 @@ func TestNewMount(t *testing.T) {
 	is.Equal(mount.Name, "test-mount")                    // name
 	is.Equal(mount.Path, "/mnt/test")                     // path
 	is.Equal(mount.CanaryPath, "/mnt/test/.health-check") // canary path
+	is.Equal(mount.CheckType, health.CheckTypeCanary)     // default check type
 	is.Equal(mount.FailureThreshold, 3)                   // failure threshold
 	is.Equal(mount.GetStatus(), health.StatusUnknown)     // initial status
 	is.Equal(mount.GetFailureCount(), 0)                  // initial failure count
+}
+
+func TestNewMountWithCheckType_Directory(t *testing.T) {
+	is := is.New(t)
+
+	mount := health.NewMountWithCheckType("test-mount", "/mnt/test", "", health.CheckTypeDirectory, 3)
+
+	is.Equal(mount.Path, "/mnt/test")                    // path
+	is.Equal(mount.CanaryPath, "")                       // no canary path for directory check
+	is.Equal(mount.CheckType, health.CheckTypeDirectory) // check type
+	is.Equal(mount.FailureThreshold, 3)                  // failure threshold
+	is.Equal(mount.GetStatus(), health.StatusUnknown)    // initial status
 }
 
 func TestNewMount_TrailingSlash(t *testing.T) {

--- a/specs/002-json-config/contracts/config-schema.json
+++ b/specs/002-json-config/contracts/config-schema.json
@@ -84,6 +84,12 @@
           "description": "Canary file path relative to this mount (overrides global default)",
           "examples": [".health-check", ".ready", "health.txt"]
         },
+        "checkType": {
+          "type": "string",
+          "description": "Health check type for this mount",
+          "enum": ["canary", "directory"],
+          "default": "canary"
+        },
         "failureThreshold": {
           "type": "integer",
           "description": "Consecutive failures before marking this mount unhealthy (overrides global default)",

--- a/specs/005-pod-restart-watchdog/contracts/config-schema.json
+++ b/specs/005-pod-restart-watchdog/contracts/config-schema.json
@@ -69,6 +69,12 @@
             "type": "string",
             "description": "Override canary file for this mount"
           },
+          "checkType": {
+            "type": "string",
+            "description": "Health check type for this mount",
+            "enum": ["canary", "directory"],
+            "default": "canary"
+          },
           "failureThreshold": {
             "type": "integer",
             "description": "Override failure threshold for this mount",


### PR DESCRIPTION
## Summary
- Add per-mount checkType support with canary as the default and directory as an explicit option
- Wire directory checks through normal monitor mode and init-container mode
- Update examples, README, schemas, and tests

## Tests
- GOCACHE=/tmp/debrid-mount-monitor-go-build go test ./...